### PR TITLE
Set aws_wafv2_web_acl.scope using var.SCOPE in waf module

### DIFF
--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -4,7 +4,7 @@ resource "aws_wafv2_web_acl" "WafAcl" {
   count       = var.create_waf_rule ? 1 : 0
   name        = var.WafAcl_name
   description = "Custom WAFWebACL"
-  scope       = "CLOUDFRONT"
+  scope       = var.SCOPE
   default_action {
     allow {}
   }


### PR DESCRIPTION
The `scope` argument for the `aws_wafv2_web_acl` resource in the `waf` module was hardcoded to "cloudfront" rather than respecting the existing input var `var.SCOPE`

*Issue #, if available:*

*Description of changes:*

Changed the hardcoded value to use the scope variable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
